### PR TITLE
Be more specific for project declared verions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,15 +29,15 @@ android {
 }
 
 dependencies {
-  def firebaseVersion = project.hasProperty('firebaseVersion') ? project.firebaseVersion : DEFAULT_FIREBASE_MESSAGING_VERSION
-  def googlePlayServicesVersion = rootProject.hasProperty('googlePlayServicesVersion')  ? rootProject.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+  def firebaseCoreVersion = project.hasProperty('firebaseCoreVersion') ? project.firebaseVersion  : project.hasProperty('firebaseVersion') ? project.firebaseVersion : DEFAULT_FIREBASE_MESSAGING_VERSION
+  def googlePlayServicesWalletVersion = rootProject.hasProperty('googlePlayServicesWalletVersion') ? project.googlePlayServicesWalletVersion : rootProject.hasProperty('googlePlayServicesVersion')  ? rootProject.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
 
   implementation fileTree(include: ['*.jar'], dir: 'libs')
   implementation 'com.facebook.react:react-native:+'
   implementation 'com.android.support:support-v4:27.1.0'
   implementation 'com.android.support:appcompat-v7:27.1.0'
-  implementation "com.google.android.gms:play-services-wallet:$googlePlayServicesVersion"
-  implementation "com.google.firebase:firebase-core:$firebaseVersion"
+  implementation "com.google.android.gms:play-services-wallet:$googlePlayServicesWalletVersion"
+  implementation "com.google.firebase:firebase-core:$firebaseCoreVersion"
   implementation 'com.stripe:stripe-android:8.1.0'
   implementation 'com.github.tipsi:CreditCardEntry:1.5.1'
 }


### PR DESCRIPTION
## Proposed changes
In many cases, firebase versions between modules are not the same. This will allow users to set a specific version for each module used. 

Example.
Firebase Core has a version 17.0.0 and a 17.0.1, but Firebase Messaging has 17.0.0, 17.0.1,17.1.0, 17.3.0, and more. It is possible to desire a version of firebase-messaging that doesn't have a mapping core version. 

This mainly comes up when trying to define project versions with react-native-push-notification since it looks at the same variable names, but for different modules.

## Types of changes
What types of changes does your code introduce to `tipsi-stripe`?  
_Put an `x` in the boxes that apply_

- [ ] Bugfix (a non-breaking change which fixes an issue)  
- [x] New feature (a non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)  

users can now specify firebaseCoreVersion and googlePlayServicesVersion at the top level of the project. Fallback will use existing `firebaseVersion` and `googlePlayServicesVersion` or the defaults if those are also not specified.

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! Next steps are a reminder of what we are going to look at before merging your code._

- [ ] I have added tests that prove my fix is useful or that my feature works  
- [ ] I have added necessary documentation (if appropriate)  
- [x] I know that my PR will be merged only if it has tests and they pass  

