### PR TITLE
Switching to a safeGet helper

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,10 @@ def DEFAULT_BUILD_TOOLS_VERSION             = '26.0.2'
 def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = '11.8.0'
 def DEFAULT_FIREBASE_MESSAGING_VERSION      = '11.8.0'
 
+def safeGet(prop, fallback) {
+  rootProject.findProperty(prop) ?: fallback
+}
+
 android {
   compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
   buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
@@ -29,8 +33,8 @@ android {
 }
 
 dependencies {
-  def firebaseCoreVersion = project.hasProperty('firebaseCoreVersion') ? project.firebaseVersion  : project.hasProperty('firebaseVersion') ? project.firebaseVersion : DEFAULT_FIREBASE_MESSAGING_VERSION
-  def googlePlayServicesWalletVersion = rootProject.hasProperty('googlePlayServicesWalletVersion') ? project.googlePlayServicesWalletVersion : rootProject.hasProperty('googlePlayServicesVersion')  ? rootProject.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+  def firebaseCoreVersion = safeGet('firebaseCoreVersion', safeGet('firebaseVersion', DEFAULT_FIREBASE_MESSAGING_VERSION ))
+  def googlePlayServicesWalletVersion = safeGet('googlePlayServicesWalletVersion', safeGet('googlePlayServicesVersion', DEFAULT_GOOGLE_PLAY_SERVICES_VERSION))
 
   implementation fileTree(include: ['*.jar'], dir: 'libs')
   implementation 'com.facebook.react:react-native:+'


### PR DESCRIPTION
This helper makes the code a little easier to follow, and also prevents typos between checking the property exists and using it.

I actually used the wrong property in the last PR. This should prevent that from happening again.

This is actually pretty common in other gradle modules. I found the `findProperty` and `elvis` operator syntax here: https://mrhaki.blogspot.com/2016/05/gradle-goodness-get-property-or-default.html

