### PR TITLE
Adjust podspec so it can be used

### DIFF
--- a/tipsi-stripe.podspec
+++ b/tipsi-stripe.podspec
@@ -3,14 +3,14 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name           = package['name']
+  s.name           = "tipsi-stripe"
   s.version        = package['version']
   s.summary        = package['description']
-  s.description    = package['description']
   s.license        = package['license']
+  
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.source         = { :git => 'https://github.com/tipsi/tipsi-stripe', :tag => s.version }
+  s.source         = { :git => 'https://github.com/tipsi/tipsi-stripe.git', :tag => s.version }
 
   s.requires_arc   = true
   s.platform       = :ios, '9.0'


### PR DESCRIPTION
* Slashes are not allowed in podspec files, and it is expected that the name of the spec matches the file name. Since the fork is published under @lifeomic/tipsi-stripe we can't use the package name. 
* removed the description field. This doesn't seem used in other packages. It also warns if the description matches the summary.
* updated source to include the .git extension. This warns as well if the extension is left off.
