### PR TITLE
Fix relative paths to headers in iOS project

### DIFF
--- a/ios/TPSStripe.xcodeproj/project.pbxproj
+++ b/ios/TPSStripe.xcodeproj/project.pbxproj
@@ -203,10 +203,10 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/../../../React/**",
-					"$(SRCROOT)/../../react-native/React/**",
-					"${SRCROOT}/../../../ios/Pods/Headers/Public",
-					"${SRCROOT}/../../../ios/Pods/Headers/Public/Stripe",
+					"$(SRCROOT)/../../../../React/**",
+					"$(SRCROOT)/../../../react-native/React/**",
+					"${SRCROOT}/../../../../ios/Pods/Headers/Public",
+					"${SRCROOT}/../../../../ios/Pods/Headers/Public/Stripe",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -250,10 +250,10 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				HEADER_SEARCH_PATHS = (
-					"$(SRCROOT)/../../../React/**",
-					"$(SRCROOT)/../../react-native/React/**",
-					"${SRCROOT}/../../../ios/Pods/Headers/Public",
-					"${SRCROOT}/../../../ios/Pods/Headers/Public/Stripe",
+					"$(SRCROOT)/../../../../React/**",
+					"$(SRCROOT)/../../../react-native/React/**",
+					"${SRCROOT}/../../../../ios/Pods/Headers/Public",
+					"${SRCROOT}/../../../../ios/Pods/Headers/Public/Stripe",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				MTL_ENABLE_DEBUG_INFO = NO;


### PR DESCRIPTION
Since the `@lifeomic/` package name prefix was added, the relative paths in the iOS build need to be updated