### PR TITLE
CON-1852: Update CreditCardFormOnChangeEvent handler to support React Native 0.64 behavior

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/CreditCardFormOnChangeEvent.java
+++ b/android/src/main/java/com/gettipsi/stripe/CreditCardFormOnChangeEvent.java
@@ -33,7 +33,7 @@ public class CreditCardFormOnChangeEvent extends Event<CreditCardFormOnChangeEve
     private WritableMap serializeEventData() {
         WritableMap eventData = Arguments.createMap();
         eventData.putBoolean("valid", isValid);
-        eventData.putMap("params", params);
+        eventData.putMap("params", params.copy());
         return eventData;
     }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tipsi/tipsi-stripe.git"
+    "url": "git+https://github.com/lifeomic/tipsi-stripe.git"
   },
   "keywords": [
     "react",

--- a/tipsi-stripe.podspec
+++ b/tipsi-stripe.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'ios/TPSStripe/**/*.{h,m}'
 
   s.dependency 'React'
-  s.dependency 'Stripe', '~> 14.0.1'
+  s.dependency 'Stripe', '~> 14.0.2'
 end


### PR DESCRIPTION
## Motivation
Three:
- Fixing the build w/ a fixed-up `repository` field.
- Addressing CON-1852 w/ https://github.com/lifeomic/tipsi-stripe/pull/25/commits/15ea28083e223c74a6f51989461abe667ed905bd.
  - I found this fix here: https://github.com/invertase/react-native-firebase/pull/5236
- Bumping stripe so we can remove the hack in `life-extend` introduced [here](https://github.com/lifeomic/life-extend/pull/1516)
