### PR TITLE
Use androidx instead of android.support

### DIFF
--- a/android/src/main/java/com/gettipsi/stripe/Errors.java
+++ b/android/src/main/java/com/gettipsi/stripe/Errors.java
@@ -1,6 +1,6 @@
 package com.gettipsi.stripe;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.gettipsi.stripe.util.ArgCheck;

--- a/android/src/main/java/com/gettipsi/stripe/GoogleApiPayFlowImpl.java
+++ b/android/src/main/java/com/gettipsi/stripe/GoogleApiPayFlowImpl.java
@@ -2,7 +2,7 @@ package com.gettipsi.stripe;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableMap;

--- a/android/src/main/java/com/gettipsi/stripe/OpenBrowserActivity.java
+++ b/android/src/main/java/com/gettipsi/stripe/OpenBrowserActivity.java
@@ -4,7 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 /**
  * Created by remer on 16/11/17.

--- a/android/src/main/java/com/gettipsi/stripe/PayFlow.java
+++ b/android/src/main/java/com/gettipsi/stripe/PayFlow.java
@@ -2,7 +2,7 @@ package com.gettipsi.stripe;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import com.facebook.react.bridge.Promise;

--- a/android/src/main/java/com/gettipsi/stripe/RedirectUriReceiver.java
+++ b/android/src/main/java/com/gettipsi/stripe/RedirectUriReceiver.java
@@ -2,7 +2,7 @@ package com.gettipsi.stripe;
 
 import android.app.Activity;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 /**

--- a/android/src/main/java/com/gettipsi/stripe/StripeModule.java
+++ b/android/src/main/java/com/gettipsi/stripe/StripeModule.java
@@ -4,8 +4,8 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.facebook.react.bridge.ActivityEventListener;

--- a/android/src/main/java/com/gettipsi/stripe/dialog/AddCardDialogFragment.java
+++ b/android/src/main/java/com/gettipsi/stripe/dialog/AddCardDialogFragment.java
@@ -5,7 +5,7 @@ import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.DialogInterface;
 import android.os.Bundle;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;

--- a/android/src/main/java/com/gettipsi/stripe/util/Converters.java
+++ b/android/src/main/java/com/gettipsi/stripe/util/Converters.java
@@ -1,7 +1,7 @@
 package com.gettipsi.stripe.util;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.facebook.react.bridge.Arguments;


### PR DESCRIPTION
These changes work when I do them manually to our app's dependency so I'm hoping it is a safe change. I wasn't able to get the example app to run in order to test this and it sounds like this library is basically on its way out so I am not super concerned 🤷 . Happy to receive push-back if others feel differently.